### PR TITLE
fix: 경기 인원 확정 API 헤더 토큰 사용으로 수정

### DIFF
--- a/src/main/java/com/example/sportspie/base/api/GameApi.java
+++ b/src/main/java/com/example/sportspie/base/api/GameApi.java
@@ -34,9 +34,9 @@ public interface GameApi {
     @Operation(summary = "Game 상세 조회 메서드", description = "로그인한 사용자가 경기 정보를 상세 조회하기 위한 메서드 입니다.")
     GameResponseDto detail(@PathVariable Long id, HttpServletRequest request);
 
-    @PatchMapping("/progress")
+    @PatchMapping("/detail/{id}/progress")
     @Operation(summary = "Game 인원 확정 메서드", description = "경기 인원 모집글 작성자가 경기 인원 확정 조건을 만족할 때 경기 인원을 확정하기 위한 메서드 입니다.")
-    ResponseEntity<StateResponse> personConfirm(@RequestBody GameUserRequestDto gameUserRequestDto);
+    ResponseEntity<StateResponse> personConfirm(@PathVariable Long id, HttpServletRequest request);
 
     @PatchMapping("/after")
     @Operation(summary = "Game 결과 확정 메서드", description = "경기 인원 모집글 작성자가 경기 결과 확정 조건을 만족할 때 경기 결과를 확정하기 위한 메서드 입니다.")

--- a/src/main/java/com/example/sportspie/bounded_context/game/controller/GameController.java
+++ b/src/main/java/com/example/sportspie/bounded_context/game/controller/GameController.java
@@ -42,15 +42,14 @@ public class GameController implements GameApi {
 
     @Override
     public GameResponseDto detail(Long id, HttpServletRequest httpServletRequest) {
-        // Long userId = jwtProvider.getUserId(jwtProvider.resolveToken(httpServletRequest).substring(7));
+        //Long userId = jwtProvider.getUserId(jwtProvider.resolveToken(httpServletRequest).substring(7));
         return gameService.detail(id);
     }
 
     @Override
-    public ResponseEntity<StateResponse> personConfirm(GameUserRequestDto gameUserRequestDto) {
-        // Long userId = jwtProvider.getUserId(jwtProvider.resolveToken(httpServletRequest).substring(7));
-        Long userId = 1L;
-        return gameService.personConfirm(gameUserRequestDto);
+    public ResponseEntity<StateResponse> personConfirm(Long gameId, HttpServletRequest request) {
+        Long userId = jwtProvider.getUserId(jwtProvider.resolveToken(request).substring(7));
+        return gameService.personConfirm(userId, gameId);
     }
 
     @Override

--- a/src/main/java/com/example/sportspie/bounded_context/game/service/GameService.java
+++ b/src/main/java/com/example/sportspie/bounded_context/game/service/GameService.java
@@ -25,7 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -87,13 +86,14 @@ public class GameService{
 
     /**
      * 경기 인원 확정
-     * @param request
+     * @param userId
+     * @param gameId
      * @return
      */
     @Transactional
-    public ResponseEntity<StateResponse> personConfirm(GameUserRequestDto request){
-        Game game = read(request.getGameId());
-        User user = userService.read(request.getUserId());
+    public ResponseEntity<StateResponse> personConfirm(Long userId, Long gameId){
+        Game game = read(gameId);
+        User user = userService.read(userId);
 
         if(!game.isAuthor(user)) throw new IllegalArgumentException("작성자만 경기 인원을 확정할 수 있습니다.");
         if(!game.isSatisfiedCapacity()) throw new IllegalArgumentException("해당 경기의 양 팀 인원 수가 맞지 않습니다.");


### PR DESCRIPTION
### 작업사항

1. JWT를 사용하여 requestDto 미사용
2. Restful을 위한 url 변경